### PR TITLE
🐛 Fix player view media context crash and migrate route to FSD slices

### DIFF
--- a/app/entities/video/ui/VidstackPlayer.tsx
+++ b/app/entities/video/ui/VidstackPlayer.tsx
@@ -220,10 +220,14 @@ export function VidstackPlayer({ video }: VidstackPlayerProps) {
     }
   };
 
-  // Only set videoSrc when both token and DRM config are ready (for local videos)
+  // Determine the playable src. We keep MediaPlayer mounted at all times so that
+  // Vidstack layout hooks always have a valid media context, even while tokens
+  // are loading asynchronously during client-side navigation.
   const videoSrc = video.videoUrl.startsWith('http')
     ? video.videoUrl
-    : (videoToken && (drmConfig || videoToken === 'external') ? `${video.videoUrl}?token=${videoToken}` : null);
+    : (videoToken && (drmConfig || videoToken === 'external') ? `${video.videoUrl}?token=${videoToken}` : undefined);
+
+  const showLoadingOverlay = isLoading || (!videoSrc && !error);
 
   if (error) {
     return (
@@ -238,7 +242,7 @@ export function VidstackPlayer({ video }: VidstackPlayerProps) {
 
   return (
     <div className="w-full h-full relative bg-background">
-      {isLoading && (
+      {showLoadingOverlay && (
         <div className="absolute inset-0 flex items-center justify-center bg-muted text-muted-foreground z-10">
           <div className="text-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-white mb-4" />
@@ -246,31 +250,29 @@ export function VidstackPlayer({ video }: VidstackPlayerProps) {
           </div>
         </div>
       )}
-      {videoSrc && (
-        <MediaPlayer
-          ref={playerRef}
-          title={video.title}
-          src={videoSrc}
-          poster={video.thumbnailUrl}
-          playsInline
-          className="w-full h-full"
-          crossOrigin=""
-          volume={0.5}
-          autoPlay={false}
-          onLoadStart={handleLoadStart}
-          onCanPlay={handleCanPlay}
-          onLoad={handleLoaded}
-          onError={handleError}
-          onProviderChange={handleProviderChange}
-        >
-          <MediaProvider />
-          <DefaultVideoLayout
-            icons={defaultLayoutIcons}
-            colorScheme="dark"
-            menuContainer=".vds-player"
-          />
-        </MediaPlayer>
-      )}
+      <MediaPlayer
+        ref={playerRef}
+        title={video.title}
+        src={videoSrc}
+        poster={video.thumbnailUrl}
+        playsInline
+        className="w-full h-full"
+        crossOrigin=""
+        volume={0.5}
+        autoPlay={false}
+        onLoadStart={handleLoadStart}
+        onCanPlay={handleCanPlay}
+        onLoad={handleLoaded}
+        onError={handleError}
+        onProviderChange={handleProviderChange}
+      >
+        <MediaProvider />
+        <DefaultVideoLayout
+          icons={defaultLayoutIcons}
+          colorScheme="dark"
+          menuContainer=".vds-player"
+        />
+      </MediaPlayer>
     </div>
   );
 }

--- a/app/pages/video-player/ui/VideoPlayerPage.tsx
+++ b/app/pages/video-player/ui/VideoPlayerPage.tsx
@@ -1,0 +1,13 @@
+import type { Video } from '~/types/video';
+import { VideoPlayerView } from '~/widgets/video-player-view/ui/VideoPlayerView';
+
+interface VideoPlayerPageProps {
+  video: Video;
+  relatedVideos: Video[];
+}
+
+export function VideoPlayerPage({ video, relatedVideos }: VideoPlayerPageProps) {
+  return (
+    <VideoPlayerView video={video} relatedVideos={relatedVideos} />
+  );
+}

--- a/app/routes/player.$id.tsx
+++ b/app/routes/player.$id.tsx
@@ -1,145 +1,88 @@
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { ArrowLeft, Download, Share2 } from 'lucide-react';
-import { Link, useLoaderData, useParams } from 'react-router';
-import { RelatedVideos } from '~/components/RelatedVideos';
-import { Badge } from '~/components/ui/badge';
-import { Button } from '~/components/ui/button';
-import { VidstackPlayer } from '~/components/VidstackPlayer';
-import { useVideoLibrary } from '~/hooks/useVideoLibrary';
+import { useLoaderData } from 'react-router';
+import type { Video } from '~/types/video';
+import { VideoPlayerPage } from '~/pages/video-player/ui/VideoPlayerPage';
 import { getVideoRepository } from '~/repositories';
 import { requireAuth } from '~/utils/auth.server';
-export async function loader({ request, params }: LoaderFunctionArgs) {
-  // Server-side authentication check
-  await requireAuth(request);
 
-  const videos = await getVideoRepository().findAll();
-  return { videos };
+interface SerializedVideo extends Omit<Video, 'createdAt'> {
+  createdAt: string;
 }
 
-export const meta: MetaFunction = () => ([
-  { title: 'Video Player - Local Streamer' },
-  { name: 'description', content: 'Local video streaming' },
-]);
+function serializeVideo(video: Video): SerializedVideo {
+  return {
+    ...video,
+    createdAt: video.createdAt.toISOString(),
+  };
+}
 
-export default function Player() {
-  const { id } = useParams();
-  const { videos: initialVideos } = useLoaderData<typeof loader>();
-  const { videos, toggleTagFilter } = useVideoLibrary(initialVideos);
+function deserializeVideo(serialized: SerializedVideo): Video {
+  return {
+    ...serialized,
+    createdAt: new Date(serialized.createdAt),
+  };
+}
 
-  // Find current video
-  const currentVideo = videos.find(video => video.id === id);
-
-  // Related videos (same tags, excluding current video)
-  const relatedVideos = videos
-    .filter(video => video.id !== id &&
-      video.tags.some(tag => currentVideo?.tags.includes(tag)))
-    .slice(0, 10);
-
-  if (!currentVideo) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold mb-2">Video not found</h1>
-          <Link to="/">
-            <Button>Back to Home</Button>
-          </Link>
-        </div>
-      </div>
-    );
+function findRelatedVideos(current: Video, allVideos: Video[]): Video[] {
+  if (current.tags.length === 0) {
+    return [];
   }
 
-  const handleTagClick = (tag: string) => {
-    toggleTagFilter(tag);
+  const currentTags = new Set(current.tags.map(tag => tag.toLowerCase()));
+
+  return allVideos
+    .filter(candidate => candidate.id !== current.id)
+    .filter(candidate => candidate.tags.some(tag => currentTags.has(tag.toLowerCase())))
+    .slice(0, 10);
+}
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  await requireAuth(request);
+
+  const videoId = params.id;
+  if (!videoId) {
+    throw new Response('Video ID is required', { status: 400 });
+  }
+
+  const videoRepository = getVideoRepository();
+  const videos = await videoRepository.findAll();
+  const currentVideo = videos.find(video => video.id === videoId);
+
+  if (!currentVideo) {
+    throw new Response('Video not found', { status: 404 });
+  }
+
+  const relatedVideos = findRelatedVideos(currentVideo, videos);
+
+  return {
+    video: serializeVideo(currentVideo),
+    relatedVideos: relatedVideos.map(serializeVideo),
   };
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data) {
+    return [
+      { title: 'Video Player - Local Streamer' },
+      { name: 'description', content: 'Local video streaming' },
+    ];
+  }
+
+  return [
+    { title: `${data.video.title} - Local Streamer` },
+    { name: 'description', content: `Watch ${data.video.title} on Local Streamer` },
+  ];
+};
+
+export default function VideoPlayerRoute() {
+  const data = useLoaderData<typeof loader>();
+  const video = deserializeVideo(data.video);
+  const relatedVideos = data.relatedVideos.map(deserializeVideo);
 
   return (
-    <div className="min-h-screen bg-background">
-      {/* Top navigation */}
-      <div className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-3">
-          <div className="flex items-center gap-4">
-            <Link to="/">
-              <Button variant="ghost" size="sm">
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Library
-              </Button>
-            </Link>
-            <div className="flex-1" />
-            <Button variant="ghost" size="sm">
-              <Share2 className="h-4 w-4" />
-            </Button>
-            <Button variant="ghost" size="sm">
-              <Download className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      {/* Main content */}
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 lg:py-6">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
-          {/* Player and info area */}
-          <div className="lg:col-span-2 space-y-4 lg:space-y-6">
-            {/* Video player */}
-            <div className="aspect-video bg-black rounded-lg overflow-hidden">
-              <VidstackPlayer video={currentVideo} />
-            </div>
-
-            {/* Video info */}
-            <div className="space-y-3 lg:space-y-4">
-              <h1 className="text-xl lg:text-2xl font-bold leading-tight">
-                {currentVideo.title}
-              </h1>
-
-              {/* Tags */}
-              <div className="flex flex-wrap gap-1.5 lg:gap-2">
-                {currentVideo.tags.map(tag => (
-                  <Badge
-                    key={tag}
-                    variant="secondary"
-                    className="text-xs lg:text-sm cursor-pointer hover:bg-primary hover:text-primary-foreground transition-colors"
-                    onClick={() => handleTagClick(tag)}
-                  >
-                    #{tag}
-                  </Badge>
-                ))}
-              </div>
-
-              {/* Description */}
-              {currentVideo.description && (
-                <div className="space-y-2">
-                  <h3 className="text-sm lg:text-base font-semibold">Description</h3>
-                  <p className="text-sm lg:text-base text-muted-foreground leading-relaxed">
-                    {currentVideo.description}
-                  </p>
-                </div>
-              )}
-
-              {/* Metadata */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 lg:gap-4 text-sm text-muted-foreground">
-                <div>
-                  <span className="font-medium">Duration:</span>
-                  <span className="ml-2">
-                    {Math.floor(currentVideo.duration / 60)}:
-                    {(currentVideo.duration % 60).toString().padStart(2, '0')}
-                  </span>
-                </div>
-                <div>
-                  <span className="font-medium">Added:</span>
-                  <span className="ml-2">
-                    {currentVideo.createdAt.toLocaleDateString()}
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Related videos sidebar */}
-          <div className="lg:col-span-1">
-            <RelatedVideos videos={relatedVideos} onTagClick={handleTagClick} />
-          </div>
-        </div>
-      </div>
-    </div>
+    <VideoPlayerPage
+      video={video}
+      relatedVideos={relatedVideos}
+    />
   );
 }

--- a/app/widgets/related-videos/ui/RelatedVideos.tsx
+++ b/app/widgets/related-videos/ui/RelatedVideos.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from 'react';
 import { Clock, Play } from 'lucide-react';
 import { Link } from 'react-router';
 import type { Video } from '~/types/video';
@@ -16,7 +17,7 @@ interface RelatedVideoItemProps {
 }
 
 function RelatedVideoItem({ video, onTagClick }: RelatedVideoItemProps) {
-  const handleTagClick = (tag: string, e: React.MouseEvent) => {
+  const handleTagClick = (tag: string, e: MouseEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
     onTagClick?.(tag);

--- a/app/widgets/video-player-view/model/useVideoPlayerView.ts
+++ b/app/widgets/video-player-view/model/useVideoPlayerView.ts
@@ -1,0 +1,56 @@
+import { useMemo, useState } from 'react';
+import type { Video } from '~/types/video';
+import { formatDuration } from '~/lib/utils';
+
+interface UseVideoPlayerViewParams {
+  video: Video;
+  relatedVideos: Video[];
+}
+
+interface TagItem {
+  value: string;
+  isActive: boolean;
+}
+
+export function useVideoPlayerView({ video, relatedVideos }: UseVideoPlayerViewParams) {
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+
+  const filteredRelatedVideos = useMemo(() => {
+    if (!activeTag) {
+      return relatedVideos;
+    }
+
+    const lowerActiveTag = activeTag.toLowerCase();
+    return relatedVideos.filter(candidate => candidate.tags.some(tag => tag.toLowerCase() === lowerActiveTag));
+  }, [activeTag, relatedVideos]);
+
+  const tagItems: TagItem[] = useMemo(() => {
+    return video.tags.map(tag => ({
+      value: tag,
+      isActive: activeTag?.toLowerCase() === tag.toLowerCase(),
+    }));
+  }, [activeTag, video.tags]);
+
+  const toggleTagFilter = (tag: string) => {
+    setActiveTag(prev => (prev?.toLowerCase() === tag.toLowerCase() ? null : tag));
+  };
+
+  const clearTagFilter = () => {
+    setActiveTag(null);
+  };
+
+  const durationLabel = useMemo(() => formatDuration(video.duration), [video.duration]);
+  const createdAtLabel = useMemo(() => video.createdAt.toLocaleDateString(), [video.createdAt]);
+
+  return {
+    video,
+    durationLabel,
+    createdAtLabel,
+    tagItems,
+    activeTag,
+    relatedVideos: filteredRelatedVideos,
+    hasTagFilter: Boolean(activeTag),
+    toggleTagFilter,
+    clearTagFilter,
+  };
+}

--- a/app/widgets/video-player-view/ui/VideoPlayerView.tsx
+++ b/app/widgets/video-player-view/ui/VideoPlayerView.tsx
@@ -1,0 +1,121 @@
+import { ArrowLeft, Download, Share2, X } from 'lucide-react';
+import { Link } from 'react-router';
+import type { Video } from '~/types/video';
+import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
+import { VidstackPlayer } from '~/entities/video/ui/VidstackPlayer';
+import { RelatedVideos } from '~/widgets/related-videos/ui/RelatedVideos';
+import { useVideoPlayerView } from '../model/useVideoPlayerView';
+
+interface VideoPlayerViewProps {
+  video: Video;
+  relatedVideos: Video[];
+}
+
+export function VideoPlayerView({ video, relatedVideos }: VideoPlayerViewProps) {
+  const {
+    durationLabel,
+    createdAtLabel,
+    tagItems,
+    relatedVideos: filteredRelatedVideos,
+    hasTagFilter,
+    toggleTagFilter,
+    clearTagFilter,
+  } = useVideoPlayerView({ video, relatedVideos });
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-4">
+            <Link to="/">
+              <Button variant="ghost" size="sm">
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Library
+              </Button>
+            </Link>
+            <div className="flex-1" />
+            <Button variant="ghost" size="sm">
+              <Share2 className="h-4 w-4" />
+            </Button>
+            <Button variant="ghost" size="sm">
+              <Download className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 lg:py-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
+          <div className="lg:col-span-2 space-y-4 lg:space-y-6">
+            <div className="aspect-video bg-black rounded-lg overflow-hidden">
+              <VidstackPlayer video={video} />
+            </div>
+
+            <div className="space-y-3 lg:space-y-4">
+              <h1 className="text-xl lg:text-2xl font-bold leading-tight">
+                {video.title}
+              </h1>
+
+              <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                <span className="font-medium">Duration:</span>
+                <span>{durationLabel}</span>
+                <span className="hidden sm:inline">•</span>
+                <span className="font-medium">Added:</span>
+                <span>{createdAtLabel}</span>
+              </div>
+
+              {video.description && (
+                <div className="space-y-2">
+                  <h3 className="text-sm lg:text-base font-semibold">Description</h3>
+                  <p className="text-sm lg:text-base text-muted-foreground leading-relaxed">
+                    {video.description}
+                  </p>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm lg:text-base font-semibold mb-1">Tags</h3>
+                  {hasTagFilter && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-xs"
+                      onClick={clearTagFilter}
+                    >
+                      <X className="h-3.5 w-3.5 mr-1" />
+                      Clear filter
+                    </Button>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-1.5 lg:gap-2">
+                  {tagItems.map(tag => (
+                    <Badge
+                      key={tag.value}
+                      variant={tag.isActive ? 'default' : 'secondary'}
+                      className="text-xs lg:text-sm cursor-pointer transition-colors"
+                      onClick={() => toggleTagFilter(tag.value)}
+                    >
+                      #{tag.value}
+                    </Badge>
+                  ))}
+                  {tagItems.length === 0 && (
+                    <span className="text-xs text-muted-foreground">No tags</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="lg:col-span-1">
+            <RelatedVideos
+              videos={filteredRelatedVideos}
+              onTagClick={toggleTagFilter}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- migrate player route to FSD-style slices for video entity, widget, and page
- keep MediaPlayer mounted while tokens/DRM load to prevent Vidstack context errors
- add playlist-aware view model for tags and related videos on player page

## Testing
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- manual Playwright navigation: home → E2E UI Video