### PR TITLE
🚸 Polish route error experience with shared alert layout

### DIFF
--- a/app/components/RouteErrorView.tsx
+++ b/app/components/RouteErrorView.tsx
@@ -1,0 +1,140 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { Info } from 'lucide-react';
+import { Link } from 'react-router';
+
+import { AppLayout } from '~/components/AppLayout';
+import { Button } from '~/components/ui/button';
+import { cn } from '~/lib/utils';
+
+type ButtonVariant = ComponentProps<typeof Button>['variant'];
+type Tone = 'neutral' | 'warning' | 'critical';
+
+type RouteErrorButtonVariant = Exclude<ButtonVariant, null | undefined>;
+
+export interface RouteErrorAction {
+  label: string;
+  to: string;
+  variant?: RouteErrorButtonVariant;
+  icon?: ReactNode;
+}
+
+export interface RouteErrorViewProps {
+  title?: string;
+  description?: ReactNode;
+  tone?: Tone;
+  icon?: ReactNode;
+  actions?: RouteErrorAction[];
+  footnote?: ReactNode;
+  layout?: 'app' | 'standalone';
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
+  pendingCount?: number;
+  children?: ReactNode;
+}
+
+const toneTokens: Record<Tone, { container: string; icon: string; title: string; description: string }> = {
+  neutral: {
+    container: 'border-border/70 bg-card/80 backdrop-blur-sm shadow-lg',
+    icon: 'bg-primary/10 text-primary',
+    title: 'text-foreground',
+    description: 'text-muted-foreground',
+  },
+  warning: {
+    container: 'border-amber-400/50 bg-amber-500/10 shadow-lg',
+    icon: 'bg-amber-500/20 text-amber-600 dark:text-amber-300',
+    title: 'text-amber-900 dark:text-amber-100',
+    description: 'text-amber-900/80 dark:text-amber-200/80',
+  },
+  critical: {
+    container: 'border-destructive/40 bg-destructive/10 shadow-lg',
+    icon: 'bg-destructive/20 text-destructive',
+    title: 'text-destructive',
+    description: 'text-destructive/80',
+  },
+};
+
+export function RouteErrorView({
+  title = 'Something went wrong',
+  description = <p>Please try again in a moment or pick a different destination.</p>,
+  tone = 'neutral',
+  icon,
+  actions,
+  footnote,
+  layout = 'app',
+  searchQuery,
+  onSearchChange,
+  pendingCount,
+  children,
+}: RouteErrorViewProps) {
+  const resolvedTone = toneTokens[tone];
+  const resolvedIcon = icon ?? <Info className="h-6 w-6" aria-hidden />;
+
+  const resolvedActions = actions?.length
+    ? actions
+    : [{ label: 'Go to home', to: '/' }];
+
+  const content = (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-10 px-6 py-16">
+      <div className={cn('rounded-3xl border p-8', resolvedTone.container)}>
+        <div className="flex flex-col gap-6">
+          <div className="flex items-start gap-4">
+            <span className={cn('inline-flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full', resolvedTone.icon)}>
+              {resolvedIcon}
+            </span>
+            <div className="space-y-3">
+              <h1 className={cn('text-2xl font-semibold leading-tight', resolvedTone.title)}>
+                {title}
+              </h1>
+              <div className={cn('text-base leading-relaxed', resolvedTone.description)}>
+                {description}
+              </div>
+            </div>
+          </div>
+
+          {children}
+
+          <div className="flex flex-wrap gap-3">
+            {resolvedActions.map(({ label, to, variant, icon: actionIcon }) => (
+              <Button
+                key={`${label}-${to}`}
+                asChild
+                variant={variant ?? 'default'}
+                className="gap-2"
+              >
+                <Link to={to}>
+                  {actionIcon}
+                  <span>{label}</span>
+                </Link>
+              </Button>
+            ))}
+          </div>
+
+          {footnote && (
+            <p className="text-sm text-muted-foreground">
+              {footnote}
+            </p>
+          )}
+        </div>
+      </div>
+
+    </div>
+  );
+
+  if (layout === 'standalone') {
+    return (
+      <div className="min-h-screen bg-background">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <AppLayout
+      searchQuery={searchQuery}
+      onSearchChange={onSearchChange}
+      pendingCount={pendingCount}
+    >
+      {content}
+    </AppLayout>
+  );
+}

--- a/app/routes/player.$id.tsx
+++ b/app/routes/player.$id.tsx
@@ -1,6 +1,9 @@
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { useLoaderData } from 'react-router';
+import { AlertTriangle, ShieldAlert, VideoOff } from 'lucide-react';
+import { isRouteErrorResponse, useLoaderData, useRouteError } from 'react-router';
+
 import type { Video } from '~/types/video';
+import { RouteErrorView } from '~/components/RouteErrorView';
 import { VideoPlayerPage } from '~/pages/video-player/ui/VideoPlayerPage';
 import { getVideoRepository } from '~/repositories';
 import { requireAuth } from '~/utils/auth.server';
@@ -83,6 +86,58 @@ export default function VideoPlayerRoute() {
     <VideoPlayerPage
       video={video}
       relatedVideos={relatedVideos}
+    />
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    if (error.status === 404) {
+      return (
+        <RouteErrorView
+          icon={<VideoOff className="h-6 w-6" aria-hidden />}
+          title="We can’t find that video"
+          description={<p>The video might have been removed or the link could be incorrect. Try another option instead.</p>}
+          actions={[
+            { label: 'Go to library', to: '/' },
+            { label: 'Browse playlists', to: '/playlists', variant: 'outline' },
+          ]}
+        />
+      );
+    }
+
+    if (error.status === 400) {
+      return (
+        <RouteErrorView
+          tone="warning"
+          icon={<ShieldAlert className="h-6 w-6" aria-hidden />}
+          title="Invalid video request"
+          description={<p>The link is missing some information. Check the address and try again.</p>}
+          actions={[
+            { label: 'Go to library', to: '/' },
+            { label: 'Browse playlists', to: '/playlists', variant: 'outline' },
+          ]}
+        />
+      );
+    }
+  }
+
+  return (
+    <RouteErrorView
+      tone="critical"
+      icon={<AlertTriangle className="h-6 w-6" aria-hidden />}
+      title="We couldn’t load the player"
+      description={
+        error instanceof Error
+          ? error.message
+          : 'Something unexpected happened while loading the video. Please try again shortly.'
+      }
+      actions={[
+        { label: 'Go to library', to: '/' },
+        { label: 'Browse playlists', to: '/playlists', variant: 'outline' },
+      ]}
     />
   );
 }

--- a/app/routes/playlists._index.tsx
+++ b/app/routes/playlists._index.tsx
@@ -1,5 +1,8 @@
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router';
-import { useLoaderData } from 'react-router';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { isRouteErrorResponse, useLoaderData, useRouteError } from 'react-router';
+
+import { RouteErrorView } from '~/components/RouteErrorView';
 import { PlaylistsPage } from '~/pages/playlists/ui/PlaylistsPage';
 // Loader function to fetch playlist data from server-side API
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -54,6 +57,46 @@ export default function Playlists() {
       total={total}
       searchQuery=""
       onSearchChange={() => {}}
+    />
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <RouteErrorView
+        tone="warning"
+        icon={<RefreshCw className="h-6 w-6" aria-hidden />}
+        title="We couldn’t load your playlists"
+        description={
+          error.data
+            ? <p>{error.data}</p>
+            : <p>Please check your connection and try again.</p>
+        }
+        actions={[
+          { label: 'Try again', to: '/playlists' },
+          { label: 'Go to home', to: '/', variant: 'outline' },
+        ]}
+      />
+    );
+  }
+
+  return (
+    <RouteErrorView
+      tone="critical"
+      icon={<AlertTriangle className="h-6 w-6" aria-hidden />}
+      title="Something went wrong"
+      description={
+        error instanceof Error
+          ? error.message
+          : 'We weren’t able to display your playlists right now. Please try again soon.'
+      }
+      actions={[
+        { label: 'Try again', to: '/playlists' },
+        { label: 'Go to home', to: '/', variant: 'outline' },
+      ]}
     />
   );
 }


### PR DESCRIPTION
## Summary
- replace the ad-hoc playlist error markup with a shared RouteErrorView component
- enhance the RouteErrorView with tone-aware styling, consistent icon sizing, and updated English copy
- opt-in to the shared error UX for playlist detail/index and player routes to keep layout and actions consistent

## Testing
- bun run lint:fix
- bun run typecheck
- bun run build
- bun run test
- manual: Playwright flow (login, private playlist, missing video)